### PR TITLE
r10k fact throws errors to stdout

### DIFF
--- a/lib/facter/r10k_path.rb
+++ b/lib/facter/r10k_path.rb
@@ -1,9 +1,9 @@
 Facter.add(:r10k_path) do
   confine :kernel => :linux
   setcode do
-    path = Facter::Util::Resolution.exec("which r10k")
-    if path
-      path.to_s
+    path = Facter::Util::Resolution.exec("which r10k 2> /dev/null")
+    if $?.success?
+      path
     else
       nil
     end


### PR DESCRIPTION
- previously this was throwing the error output to stdout instead of to /dev/null upon every facter call
- fixes conditional to check if command succeeding rather than if path exists, since the path will always be a string
